### PR TITLE
replaced Makefile by justfile and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,14 @@
 
 Download the latest release.
 ```
-wget wget https://github.com/bfoersterling/mdtoc/releases/latest/download/mdtoc_linux_amd64 -O mdtoc
-chmod +x mdtoc
-sudo install mdtoc /usr/local/bin
+wget https://github.com/bfoersterling/mdtoc/releases/latest/download/mdtoc_linux_amd64 -O mdtoc
+sudo install -v -m 755 mdtoc /usr/local/bin
 ```
 
 Or build it:
 ```
-make
-sudo make install
+git clone https://github.com/bfoersterling/mdtoc.git
+sudo just install
 ```
 
 ## Usage

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-all:
+default:
 	go build .
 
 run:
@@ -10,8 +10,8 @@ test:
 	go run . test_files/weird_headers.md
 	go run . test_files/audio.md
 
-install:
-	cp -v mdtoc /usr/local/bin/.
+install: default
+	install -v -m 755 mdtoc /usr/local/bin/.
 
 clean:
 	go clean


### PR DESCRIPTION
`just` is a more modern and more user friendly way to build projects that are written in simple languages like `Go`.