### PR TITLE
fix emph nodes in print_colored_markdown()

### DIFF
--- a/pretty_printer.c
+++ b/pretty_printer.c
@@ -11,6 +11,7 @@ static int number_of_leading_nl(cmark_node* node);
 static void pretty_print_cmark_block_quote(cmark_node* node, FILE* stream);
 static void pretty_print_cmark_code(cmark_node* node, FILE* stream);
 static void pretty_print_cmark_code_block(cmark_node* node, FILE* stream);
+static void pretty_print_cmark_emph(cmark_node* node, FILE* stream);
 static void pretty_print_cmark_heading(cmark_node* node, FILE* stream);
 static void pretty_print_cmark_html_block(cmark_node* node, FILE* stream);
 static void pretty_print_cmark_html_inline(cmark_node* node, FILE* stream);
@@ -103,6 +104,11 @@ pretty_print_cmark_code_block(cmark_node* node, FILE* stream)
 	}
 
 	free(code_block_copy);
+}
+
+	static void
+pretty_print_cmark_emph(cmark_node* node, FILE* stream)
+{
 }
 
 	static void
@@ -201,6 +207,9 @@ pretty_print_cmark_node(cmark_node* node, FILE* stream)
 			pretty_print_cmark_code_block(node, stream);
 			break;
 		case CMARK_NODE_DOCUMENT:
+			break;
+		case CMARK_NODE_EMPH:
+			pretty_print_cmark_emph(node, stream);
 			break;
 		case CMARK_NODE_HEADING:
 			pretty_print_cmark_heading(node, stream);

--- a/test/parser_test.c
+++ b/test/parser_test.c
@@ -434,6 +434,25 @@ START_TEST (test_print_colored_markdown)
 
 	free(buffer_8);
 	fclose(stream_8);
+
+	// 9 - emph
+	const char* input_9 =
+		"This is *emphasized* and the rest is normal.\n";
+
+	const char* expected_9 =
+		"\033[0mThis is emphasized\033[0m and the rest is normal.\n\033[0m";
+
+	size_t buffer_size_9 = strlen(expected_9) * 2;
+	char* buffer_9 = malloc(buffer_size_9);
+	memset(buffer_9, 0, buffer_size_9);
+	FILE* stream_9 = fmemopen(buffer_9, buffer_size_9, "w");
+
+	print_colored_markdown(input_9, stream_9);
+
+	ck_assert_str_eq(buffer_9, expected_9);
+
+	free(buffer_9);
+	fclose(stream_9);
 }
 
 START_TEST (test_update_heading_levels)


### PR DESCRIPTION
do not print error message for emph nodes - have an empty function instead