### PR TITLE
Extract all literals from headings

### DIFF
--- a/docs/commonmark_headings.md
+++ b/docs/commonmark_headings.md
@@ -1,0 +1,41 @@
+# commonmark headings
+
+According to https://spec.commonmark.org/0.31.2/ headings are "leaf blocks".
+
+> Some blocks (like block quotes and list items) contain other blocks;\
+others (like headings and paragraphs) contain inline content—text, links,\
+emphasized text, images, code spans, and so on.
+
+=> So headings can only contain `inline` content.
+
+## infinite children
+
+A heading in commonmark can have infinite children.
+
+Example:
+```
+## [a link with *italic and **bold with *italic* in it** content* in it](https://example.com)
+```
+The ast will look like this:
+```
+heading [1, 1] - [1, 90]
+    link [1, 4] - [1, 90]
+      text [1, 5] - [1, 16]
+      emph [1, 17] - [1, 62]
+        text [1, 18] - [1, 28]
+        strong [1, 29] - [1, 56]
+          text [1, 31] - [1, 40]
+          emph [1, 41] - [1, 48]
+            text [1, 42] - [1, 47]
+          text [1, 49] - [1, 54]
+        text [1, 57] - [1, 61]
+      text [1, 63] - [1, 68]
+```
+
+## maximum number of characters
+
+A heading cannot span over multiple lines with `\`.
+
+Sane people will not use more than 80 characters for a heading.
+
+It is probably fair to use `LINE_MAX` from `limits.h` for a buffer size.

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <cmark.h>
 #include <errno.h>
+#include <limits.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -11,7 +12,8 @@
 
 // Static function prototypes.
 static void append_heading(struct heading** head, const char* text, int level, int levels[6], int line);
-static const char* extract_heading_text(cmark_node* node);
+static void concat_all_literals(cmark_node* node, char* buffer);
+static char* extract_heading_text(cmark_node* node);
 static struct heading* find_connector(struct heading* node, int level);
 static void insert_preamble_heading(struct heading** head, const char* source_code);
 static void parse_headings_from_node(cmark_node* node, struct heading** head, int levels[6]);
@@ -65,19 +67,38 @@ append_heading(struct heading** head, const char* text, int level, int levels[6]
 	connector->next = new_node;
 }
 
-	static const char*
+// Traverse node and concatenate the literals from all children and siblings
+// in "buffer".
+// The caller has to provide an allocated buffer "buffer" with enough space.
+	static void
+concat_all_literals(cmark_node* node, char* buffer)
+{
+	const char* literal = cmark_node_get_literal(node);
+
+	if (literal != NULL)
+		strcat(buffer, literal);
+
+	if (cmark_node_first_child(node) != NULL)
+		concat_all_literals(cmark_node_first_child(node), buffer);
+
+	if (cmark_node_next(node) != NULL)
+		concat_all_literals(cmark_node_next(node), buffer);
+}
+
+// Extracts only the literals from the heading for the toc.
+// Caller has to free the returned buffer.
+	static char*
 extract_heading_text(cmark_node* node)
 {
 	assert(cmark_node_get_type(node) == CMARK_NODE_HEADING);
 
-	cmark_node* first_child = cmark_node_first_child(node);
+	size_t buffer_size = LINE_MAX;
+	char* buffer = malloc(buffer_size);
+	memset(buffer, 0, buffer_size);
 
-	if (cmark_node_get_type(first_child) != CMARK_NODE_LINK)
-		return cmark_node_get_literal(first_child);
+	concat_all_literals(cmark_node_first_child(node), buffer);
 
-	// The heading consists of a link and we need to get the literal of its
-	// child.
-	return cmark_node_get_literal(cmark_node_first_child(first_child));
+	return buffer;
 }
 
 // "node" should be the root of the tree.
@@ -237,12 +258,15 @@ parse_headings_from_node(cmark_node* node, struct heading** head, int hlevels[6]
 	if (cmark_node_get_type(node) == CMARK_NODE_HEADING) {
 		int hlevel = cmark_node_get_heading_level(node);
 		update_heading_levels(hlevel, hlevels);
+		char* heading_literal = extract_heading_text(node);
 
 		append_heading(head,
-				(char*)extract_heading_text(node),
+				heading_literal,
 				hlevel,
 				hlevels,
 				cmark_node_get_start_line(node));
+
+		free(heading_literal);
 	}
 
 	if (cmark_node_first_child(node) != NULL)

--- a/test/parser_test.c
+++ b/test/parser_test.c
@@ -215,6 +215,31 @@ START_TEST (test_parse_headings)
 	free(buffer_5);
 	fclose(stream_5);
 	free_heading_tree(head_5);
+
+	// 6 - heading with nested content
+	const char* source_6 =
+		"## [link with nested **strong *and emph* content**]"
+		"(https://example.com)\n"
+		"## normal heading\n";
+
+	const char* expected_6 =
+		"1. link with nested strong and emph content (1)\n"
+		"2. normal heading (2)\n";
+
+	struct heading* head_6 = parse_headings(source_6);
+
+	size_t buffer_size_6 = 128;
+	char* buffer_6 = malloc(buffer_size_6);
+	memset(buffer_6, 0, buffer_size_6);
+	FILE* stream_6 = fmemopen(buffer_6, buffer_size_6, "w");
+
+	print_heading_tree(head_6, 0, stream_6);
+
+	ck_assert_str_eq(buffer_6, expected_6);
+
+	free(buffer_6);
+	fclose(stream_6);
+	free_heading_tree(head_6);
 }
 
 START_TEST (test_pretty_heading_levels)


### PR DESCRIPTION
Problem:
Currently only the first child of a heading will be used for the heading text.

Solution:
Traverse through all children and only extract the literals.