### PR TITLE
refactored print_chapter

### DIFF
--- a/src/chapter.c
+++ b/src/chapter.c
@@ -216,14 +216,15 @@ parse_chapters_from_headings(
 }
 
 /*
- * Prints chapter "chapter" from file "source_file".
+ * Prints chapter "chapter" from string "source_code".
+ * "source_code": The content of a markdown file.
  * "chapter": i.e. "1.2." or "1.2" (trailing dot will be appended).
  * "stream": Output stream. (i.e. stdout or string stream for tests)
  */
 	void
-print_chapter(FILE* source_file, const char* chapter, FILE* stream)
+print_chapter(const char* source_code, const char* chapter, FILE* stream)
 {
-	assert(source_file != NULL);
+	assert(source_code != NULL);
 	assert(chapter != NULL);
 
 	if (*chapter == '\0') {
@@ -231,18 +232,14 @@ print_chapter(FILE* source_file, const char* chapter, FILE* stream)
 		return;
 	}
 
+	if (*source_code == '\0') {
+		fprintf(stream, "Source code is an empty string.\n");
+		return;
+	}
+
 	char* dotted_numbering = numbering_with_trailing_dot(chapter);
 
-	size_t source_size = file_size(source_file) + 1;
-	char* source = malloc(source_size);
-	memset(source, 0, source_size);
-
-	long initial_file_pos = ftell(source_file);
-	fseek(source_file, 0, SEEK_SET);
-	fread(source, source_size, 1, source_file);
-	fseek(source_file, initial_file_pos, SEEK_SET);
-
-	struct chapter* root_chapter = parse_chapters(source);
+	struct chapter* root_chapter = parse_chapters(source_code);
 
 	struct chapter* needle_chapter =
 		find_chapter_by_numbering(root_chapter, dotted_numbering);
@@ -271,7 +268,6 @@ print_chapter(FILE* source_file, const char* chapter, FILE* stream)
 	free(heading_str);
 end:
 	free(dotted_numbering);
-	free(source);
 	free_chapter_tree(root_chapter);
 }
 

--- a/src/chapter.h
+++ b/src/chapter.h
@@ -17,7 +17,7 @@ void free_chapter_tree(struct chapter* node);
 struct chapter* parse_chapters(const char* source_code);
 void search_chapters_for_str(const char* source_code, const char* str,
 		FILE* stream);
-void print_chapter(FILE* source_file, const char* chapter, FILE* stream);
+void print_chapter(const char* source_code, const char* chapter, FILE* stream);
 void print_chapter_no_color(const char* source_code, const char* chapter, FILE* stream);
 void print_chapter_with_color(const char* source_code, const char* chapter, FILE* stream);
 bool use_color(void);

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -109,15 +109,13 @@ ia_chapter(const char* file_path, const char* user_input)
 		if (counter == 0
 				&& strcmp(token, "c") != 0 && strcmp(token, "chapter")) {
 			printf("Unknown command %s.\n", token);
-			free(user_input_copy);
-			return;
+			goto end;
 		}
 
 		if (counter > 1) {
 			printf("Command \"chapter\" only accepts one argument.\n");
 			printf("Received \"%s\".\n", token);
-			free(user_input_copy);
-			return;
+			goto end;
 		}
 
 		if (counter == 1) {
@@ -129,22 +127,15 @@ ia_chapter(const char* file_path, const char* user_input)
 
 	if (chapter == NULL) {
 		printf("Command \"chapter\" requires one argument.\n");
-		free(user_input_copy);
-		return;
+		goto end;
 	}
 
-	FILE* source_file = fopen(file_path, "r");
+	char* source_code = read_file(file_path, false);
 
-	if (source_file == NULL) {
-		printf("Error opening file \"%s\": %s\n", file_path, strerror(errno));
-		free(user_input_copy);
-		return;
-	}
+	print_chapter(source_code, chapter, stdout);
 
-	print_chapter(source_file, chapter, stdout);
-
-	fclose(source_file);
-
+	free(source_code);
+end:
 	free(user_input_copy);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -30,6 +30,7 @@ handle_cli_args(int argc, char** argv)
 	int c = 0;
 	int option_index = 0;
 	const char* file_path = NULL;
+	char* source_code = NULL;
 
 	while(c != -1) {
 		c = getopt_long(argc, argv, "hive:c:s:", cli_args, &option_index);
@@ -42,17 +43,11 @@ handle_cli_args(int argc, char** argv)
 				}
 				file_path = argv[optind - option_index];
 
-				FILE* md_file = fopen(file_path, "r");
+				source_code = read_file(file_path, true);
 
-				if (md_file == NULL) {
-					fprintf(stderr, "Error opening file \"%s\": %s\n",
-							file_path, strerror(errno));
-					exit(1);
-				}
+				print_chapter(source_code, optarg, stdout);
 
-				print_chapter(md_file, optarg, stdout);
-
-				fclose(md_file);
+				free(source_code);
 
 				exit(0);
 				break;
@@ -79,7 +74,7 @@ handle_cli_args(int argc, char** argv)
 				}
 				file_path = argv[optind];
 
-				char* source_code = read_file(file_path, true);
+				source_code = read_file(file_path, true);
 
 				search_chapters_for_str(source_code, optarg, stdout);
 


### PR DESCRIPTION
Since there is already `read_file()` we do not need to read a file inside `print_chapter()`.
That is unnecessary code duplication.
Especially as we would still have to open a file and check for `NULL`.
Also makes it easier to test the function.